### PR TITLE
[BPK-4115]: Add shorthand support

### DIFF
--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+# 1.2.0 - Added support for shorthand rules
+ADDED:
+  `use-tokens`
+    - This rule now supports shorthand CSS props `margin`, `padding`, `border-radius` and `border-width` for linting.
+
 # 1.1.0 - Updated linting rules
 ADDED:
   `use-tokens`

--- a/lib/rules/use-tokens/__tests__/index.test.js
+++ b/lib/rules/use-tokens/__tests__/index.test.js
@@ -104,17 +104,6 @@ describe('Spacing token tests', () => {
 
     expect(warnings).toHaveLength(0);
   });
-
-  it('should not throw any warnings when an ignored shorthand is used', async () => {
-    const {
-      results: [{ warnings }],
-    } = await lint({
-      code: '@mixin bpk-blockquote { margin: 0 0 $bpk-spacing-sm 0; }',
-      config,
-    });
-
-    expect(warnings).toHaveLength(0);
-  });
 });
 
 describe('Radii token tests', () => {
@@ -122,14 +111,14 @@ describe('Radii token tests', () => {
     const {
       results: [{ warnings }],
     } = await lint({
-      code: 'a { borderRadius: $bpk-border-radius-sm; font-size: 14rem }',
+      code: 'a { border-radius: $bpk-border-radius-sm; font-size: 14rem }',
       config,
     });
 
     expect(warnings).toHaveLength(0);
   });
 
-  it('should not throw an error when a function is used', async () => {
+  it('should throw an error when a function is used', async () => {
     const {
       results: [{ warnings }],
     } = await lint({
@@ -138,7 +127,10 @@ describe('Radii token tests', () => {
       config,
     });
 
-    expect(warnings).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].text).toBe(
+      "Don't use raw numbers for `border-radius` instead use a Backpack token or multiples of a token (backpack/use-tokens)",
+    );
   });
 
   it('throws an error when using raw number', async () => {
@@ -181,7 +173,7 @@ describe('Border token tests', () => {
     expect(warnings).toHaveLength(0);
   });
 
-  it('should not throw as it uses a function', async () => {
+  it('should throw as it uses a function', async () => {
     const {
       results: [{ warnings }],
     } = await lint({
@@ -190,7 +182,10 @@ describe('Border token tests', () => {
       config,
     });
 
-    expect(warnings).toHaveLength(0);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].text).toBe(
+      "Don't use raw numbers for `border-width` instead use a Backpack token or multiples of a token (backpack/use-tokens)",
+    );
   });
 
   it('throws an error when using raw number', async () => {
@@ -208,12 +203,39 @@ describe('Border token tests', () => {
     );
   });
 
+  it('throws an error when specifying a number and token', async () => {
+    const {
+      results: [{ warnings }],
+    } = await lint({
+      code:
+        '@import "~bpk-mixins/index"; a { border-width: 5rem  $bpk-border-size-sm 5rem $bpk-border-size-sm; font-size: 14rem; }',
+      config,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].text).toBe(
+      "Don't use raw numbers for `border-width` instead use a Backpack token or multiples of a token (backpack/use-tokens)",
+    );
+  });
+
   it('should pass when using custom variable', async () => {
     const {
       results: [{ warnings }],
     } = await lint({
       code:
         '@import "~bpk-mixins/index"; $border-val:5rem a { border-width: $radius-val; font-size: 14rem; }',
+      config,
+    });
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('should pass when using border-top-width', async () => {
+    const {
+      results: [{ warnings }],
+    } = await lint({
+      code:
+        '@import "~bpk-mixins/index"; { border-top-width: $bpk-border-size-sm; font-size: 14rem; }',
       config,
     });
 

--- a/lib/rules/use-tokens/index.js
+++ b/lib/rules/use-tokens/index.js
@@ -16,8 +16,9 @@
 const stylelint = require('stylelint');
 const { parse } = require('postcss-values-parser');
 
-const { ALLOWED_PROPS } = require('../../utils/token-props');
+const { SHORTHAND_PROPS } = require('../../utils/token-props');
 
+const parseShorthand = require('./parseShorthand');
 const {
   isLengthProp,
   isBpkToken,
@@ -36,6 +37,16 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
     return `Don't use raw numbers for \`${selector}\` instead use a Backpack token or multiples of a token`;
   },
 });
+
+function createReport(result, message, node, word) {
+  stylelint.utils.report({
+    ruleName,
+    result,
+    message,
+    node,
+    word,
+  });
+}
 
 const rule = primaryOption => {
   return (postcssRoot, postcssResult) => {
@@ -61,37 +72,38 @@ const rule = primaryOption => {
       // Return early if css identifier is not a size to avoid needlessly parsing
       if (!isLengthProp(prop)) return;
 
-      if (ALLOWED_PROPS.includes(prop)) return;
-
       // Parse the values so we can test
       const root = parse(value, { ignoreUnknownWords: true });
-
-      root.nodes.forEach(element => {
-        // If allowed value or unit or Backpack token is used then we return
-        if (
-          isBpkToken(element.value) ||
-          isAllowedValue(element.value) ||
-          isAllowedUnit(element.unit)
-        )
-          return;
-
-        // If its a word and the value does not match expected values we report and error
-        if (element.type === 'word' && !checkValue(element.value)) {
-          message = messages.expected(prop, element.type);
-        } else if (element.type === 'numeric') {
-          message = messages.expected(prop, element.type);
-        } else {
-          return;
+      if (SHORTHAND_PROPS.includes(prop)) {
+        if (!parseShorthand(value)) {
+          createReport(
+            postcssResult,
+            messages.expected(prop, null),
+            decl,
+            value,
+          );
         }
-        // Report back the violation
-        stylelint.utils.report({
-          ruleName,
-          result: postcssResult,
-          message,
-          node: decl,
-          word: value,
+      } else {
+        root.nodes.forEach(element => {
+          // If allowed value or unit or Backpack token is used then we return
+          if (
+            isBpkToken(element.value) ||
+            isAllowedValue(element.value) ||
+            isAllowedUnit(element.unit)
+          )
+            return;
+
+          // If its a word and the value does not match expected values we report and error
+          if (element.type === 'word' && !checkValue(element.value)) {
+            message = messages.expected(prop, element.type);
+          } else if (element.type === 'numeric') {
+            message = messages.expected(prop, element.type);
+          } else {
+            return;
+          }
+          createReport(postcssResult, message, decl, value);
         });
-      });
+      }
     });
   };
 };

--- a/lib/rules/use-tokens/parseShorthand.js
+++ b/lib/rules/use-tokens/parseShorthand.js
@@ -1,0 +1,14 @@
+const { isBpkToken, isAllowedValue, checkValue } = require('./utils');
+
+module.exports = function parseShorthand(value) {
+  const shorthandValues = value.split(' ');
+  let validValue = true;
+
+  shorthandValues.forEach(val => {
+    if (isBpkToken(val) || isAllowedValue(val) || checkValue(val)) {
+      return;
+    }
+    validValue = false;
+  });
+  return validValue;
+};

--- a/lib/rules/use-tokens/utils.js
+++ b/lib/rules/use-tokens/utils.js
@@ -2,7 +2,6 @@ const {
   RADII_PROPS,
   BORDER_PROPS,
   SPACING_PROPS,
-  // ALLOWED_PROPS,
   ALLOWED_VALUES,
 } = require('../../utils/token-props');
 const { tokensByCategory } = require('../../utils/token-utils');

--- a/lib/utils/token-props.js
+++ b/lib/utils/token-props.js
@@ -40,6 +40,7 @@ module.exports.SPACING_PROPS = [
   'end',
   'height',
   'left',
+  'margin',
   'margin-bottom',
   'margin-end',
   'margin-horizontal',
@@ -52,6 +53,7 @@ module.exports.SPACING_PROPS = [
   'max-width',
   'min-height',
   'min-width',
+  'padding',
   'padding-bottom',
   'padding-end',
   'padding-horizontal',
@@ -66,8 +68,12 @@ module.exports.SPACING_PROPS = [
   'width',
 ];
 
-// Temp to exclude shorthand props from being checked.
-// TODO: Create a way to decontruct shorthand props
-module.exports.ALLOWED_PROPS = ['margin', 'padding'];
+// Shorthand props to be expanded and searched.
+module.exports.SHORTHAND_PROPS = [
+  'margin',
+  'padding',
+  'border-radius',
+  'border-width',
+];
 
 module.exports.ALLOWED_VALUES = ['auto', '0'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1080,7 +1080,7 @@
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@types/minimist/-/minimist-1.2.0.tgz",
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
@@ -2231,7 +2231,7 @@
     },
     "decamelize-keys": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
       "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
       "requires": {
         "decamelize": "^1.1.0",
@@ -2240,7 +2240,7 @@
       "dependencies": {
         "map-obj": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/map-obj/-/map-obj-1.0.1.tgz",
           "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
         }
       }
@@ -3463,7 +3463,7 @@
     },
     "globjoin": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM="
     },
     "gonzales-pe": {
@@ -3874,7 +3874,7 @@
     },
     "indexes-of": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
     },
     "inflight": {
@@ -3978,7 +3978,7 @@
     },
     "is-alphanumeric": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-alphanumeric/-/is-alphanumeric-1.0.0.tgz",
       "integrity": "sha1-Spzvcdr0wAHB2B1j0UDPU/1oifQ="
     },
     "is-alphanumerical": {
@@ -4081,7 +4081,7 @@
     },
     "is-extglob": {
       "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
     },
     "is-fullwidth-code-point": {
@@ -6762,12 +6762,12 @@
     },
     "normalize-range": {
       "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI="
     },
     "normalize-selector": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/normalize-selector/-/normalize-selector-0.2.0.tgz",
       "integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM="
     },
     "npm-run-path": {
@@ -6781,7 +6781,7 @@
     },
     "num2fraction": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4="
     },
     "nwsapi": {
@@ -7170,7 +7170,7 @@
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
       "integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
     },
     "postcss-reporter": {
@@ -7196,7 +7196,7 @@
     },
     "postcss-resolve-nested-selector": {
       "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
       "integrity": "sha1-Kcy8fDfe36wwTp//C/FZaz9qDk4="
     },
     "postcss-safe-parser": {
@@ -7538,7 +7538,7 @@
     },
     "replace-ext": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/replace-ext/-/replace-ext-1.0.0.tgz",
       "integrity": "sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs="
     },
     "request": {
@@ -8448,7 +8448,7 @@
     },
     "style-search": {
       "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI="
     },
     "stylelint": {
@@ -8645,7 +8645,7 @@
     },
     "svg-tags": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/svg-tags/-/svg-tags-1.0.0.tgz",
       "integrity": "sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q="
     },
     "symbol-tree": {
@@ -8838,7 +8838,7 @@
     },
     "trim": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "trim-newlines": {
@@ -8961,7 +8961,7 @@
     },
     "uniq": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unist-util-find-all-after": {
@@ -9090,7 +9090,7 @@
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {


### PR DESCRIPTION
ADDED:
  `use-tokens`
    - This rule now supports shorthand CSS props `margin`, `padding`, `border-radius` and `border-width` for linting.