### PR TITLE
[BPK-4283]: Fix multiplication of tokens

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
+
+defaults:
+  run:
+    shell: bash -l {0}
 
 jobs:
   build:
@@ -12,8 +16,13 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: nvm install
+        run: nvm install
+
       - name: Install
         run: npm ci
 
       - name: Test
-        run: npm test
+        run: |
+          nvm use 
+          npm test

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/erbium

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- `use-tokens`
+  - Fixed issue where multiplications of tokens threw errors instead of passing.
 
 ## How to write a good changelog entry
 

--- a/lib/rules/use-tokens/__tests__/index.test.js
+++ b/lib/rules/use-tokens/__tests__/index.test.js
@@ -34,6 +34,17 @@ describe('Spacing token tests', () => {
     expect(warnings).toHaveLength(0);
   });
 
+  it('passes when using multiples of spacing', async () => {
+    const {
+      results: [{ warnings }],
+    } = await lint({
+      code: 'a { width: $bpk-spacing-md * 2; font-size: 14rem }',
+      config,
+    });
+
+    expect(warnings).toHaveLength(0);
+  });
+
   it('passes when setting negative number', async () => {
     const {
       results: [{ warnings }],
@@ -77,6 +88,20 @@ describe('Spacing token tests', () => {
     });
 
     expect(warnings).toHaveLength(0);
+  });
+
+  it('fails when using multiples of numbers', async () => {
+    const {
+      results: [{ warnings }],
+    } = await lint({
+      code: 'a { width: 2rem * 2; font-size: 14rem }',
+      config,
+    });
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0].text).toBe(
+      "Don't use raw numbers for `width` instead use a Backpack token or multiples of a token (backpack/use-tokens)",
+    );
   });
 
   it('throws an error when using raw number', async () => {

--- a/lib/rules/use-tokens/index.js
+++ b/lib/rules/use-tokens/index.js
@@ -74,6 +74,7 @@ const rule = primaryOption => {
       // Parse the values so we can test
       const root = parse(value, { ignoreUnknownWords: true });
 
+      // Handle any use of shorthand CSS props here.
       if (SHORTHAND_PROPS.includes(prop)) {
         if (!parseShorthand(value)) {
           createReport(
@@ -112,6 +113,8 @@ const rule = primaryOption => {
             message = messages.expected(prop, element.type);
           }
         });
+
+        // If we have found violations we report the issue to the user.
         if (message) {
           createReport(postcssResult, message, decl, value);
         }

--- a/lib/rules/use-tokens/index.js
+++ b/lib/rules/use-tokens/index.js
@@ -63,7 +63,6 @@ const rule = primaryOption => {
     if (!validOptions) {
       return;
     }
-
     postcssRoot.walkDecls(decl => {
       const { prop, value } = decl;
 
@@ -74,6 +73,7 @@ const rule = primaryOption => {
 
       // Parse the values so we can test
       const root = parse(value, { ignoreUnknownWords: true });
+
       if (SHORTHAND_PROPS.includes(prop)) {
         if (!parseShorthand(value)) {
           createReport(
@@ -84,6 +84,16 @@ const rule = primaryOption => {
           );
         }
       } else {
+        // If the value is just a bpk token, allowed value or is a multiplication of bpk tokens then we aren't violating rules.
+        if (
+          isBpkToken(value) ||
+          isAllowedValue(value) ||
+          (value.includes('$bpk-') && value.includes('*'))
+        ) {
+          return;
+        }
+
+        // For more complex SASS we parse each node in the supplied property to parse.
         root.nodes.forEach(element => {
           // If allowed value or unit or Backpack token is used then we return
           if (
@@ -94,15 +104,16 @@ const rule = primaryOption => {
             return;
 
           // If its a word and the value does not match expected values we report and error
-          if (element.type === 'word' && !checkValue(element.value)) {
+          if (
+            (element.type === 'word' && !checkValue(element.value)) ||
+            element.type === 'numeric'
+          ) {
             message = messages.expected(prop, element.type);
-          } else if (element.type === 'numeric') {
-            message = messages.expected(prop, element.type);
-          } else {
-            return;
           }
-          createReport(postcssResult, message, decl, value);
         });
+        if (message) {
+          createReport(postcssResult, message, decl, value);
+        }
       }
     });
   };

--- a/lib/rules/use-tokens/index.js
+++ b/lib/rules/use-tokens/index.js
@@ -104,6 +104,7 @@ const rule = primaryOption => {
             return;
 
           // If its a word and the value does not match expected values we report and error
+          // or if the value is numeric we report users should be using bpk tokens for properties
           if (
             (element.type === 'word' && !checkValue(element.value)) ||
             element.type === 'numeric'


### PR DESCRIPTION
This PR fixes the issue whereby using multiples of bpk-tokens would throw and error which was false.

e.g.
```js
width: $bpk-spacing-md * 2
```

This previously was throwing and error which was incorrect.