### PR TITLE
Fix rule value setting

### DIFF
--- a/lib/rules/use-colors/__tests__/index.test.js
+++ b/lib/rules/use-colors/__tests__/index.test.js
@@ -94,3 +94,22 @@ it('gives a color blue is not valid error and to use a token', async () => {
     'The color "blue" is not a valid colour for "color". Use a Backpack token instead',
   );
 });
+
+it('should not run/report issues when disabled', async () => {
+  const {
+    errored,
+    results: [{ warnings, invalidOptionWarnings }],
+  } = await lint({
+    code: 'a { color: $bpk-color-sky-blue; font-size: 14rem }',
+    config: {
+      plugins: ['./index.js'],
+      rules: {
+        'backpack/use-colors': false,
+      },
+    },
+  });
+
+  expect(errored).toBeFalsy();
+  expect(warnings).toHaveLength(0);
+  expect(invalidOptionWarnings).toHaveLength(0);
+});

--- a/lib/rules/use-colors/index.js
+++ b/lib/rules/use-colors/index.js
@@ -49,7 +49,16 @@ const messages = stylelint.utils.ruleMessages(ruleName, {
 const rule = primaryOption => {
   return (postcssRoot, postcssResult) => {
     // If rule is disabled then we don't run the rule
-    if (!primaryOption) {
+    const validOptions = stylelint.utils.validateOptions(
+      postcssResult,
+      ruleName,
+      {
+        actual: primaryOption,
+        possible: [true, false],
+      },
+    );
+
+    if (!validOptions) {
       return;
     }
 

--- a/lib/rules/use-tokens/__tests__/index.test.js
+++ b/lib/rules/use-tokens/__tests__/index.test.js
@@ -129,10 +129,29 @@ describe('Spacing token tests', () => {
 
     expect(warnings).toHaveLength(0);
   });
+
+  it('should not run/report issues when disabled', async () => {
+    const {
+      errored,
+      results: [{ warnings, invalidOptionWarnings }],
+    } = await lint({
+      code: 'a { width: $bpk-spacing-sm; }',
+      config: {
+        plugins: ['./index.js'],
+        rules: {
+          'backpack/use-tokens': false,
+        },
+      },
+    });
+
+    expect(errored).toBeFalsy();
+    expect(warnings).toHaveLength(0);
+    expect(invalidOptionWarnings).toHaveLength(0);
+  });
 });
 
 describe('Radii token tests', () => {
-  it('passes when setting spacing', async () => {
+  it('passes when setting radius', async () => {
     const {
       results: [{ warnings }],
     } = await lint({
@@ -184,10 +203,29 @@ describe('Radii token tests', () => {
 
     expect(warnings).toHaveLength(0);
   });
+
+  it('should not run/report issues when disabled', async () => {
+    const {
+      errored,
+      results: [{ warnings, invalidOptionWarnings }],
+    } = await lint({
+      code: 'a { border-radius: $bpk-border-radius-sm; }',
+      config: {
+        plugins: ['./index.js'],
+        rules: {
+          'backpack/use-tokens': false,
+        },
+      },
+    });
+
+    expect(errored).toBeFalsy();
+    expect(warnings).toHaveLength(0);
+    expect(invalidOptionWarnings).toHaveLength(0);
+  });
 });
 
 describe('Border token tests', () => {
-  it('passes when setting spacing', async () => {
+  it('passes when setting border-width', async () => {
     const {
       results: [{ warnings }],
     } = await lint({
@@ -265,5 +303,24 @@ describe('Border token tests', () => {
     });
 
     expect(warnings).toHaveLength(0);
+  });
+
+  it('should not run/report issues when disabled', async () => {
+    const {
+      errored,
+      results: [{ warnings, invalidOptionWarnings }],
+    } = await lint({
+      code: 'a { border-width: $bpk-border-size-sm; }',
+      config: {
+        plugins: ['./index.js'],
+        rules: {
+          'backpack/use-tokens': false,
+        },
+      },
+    });
+
+    expect(errored).toBeFalsy();
+    expect(warnings).toHaveLength(0);
+    expect(invalidOptionWarnings).toHaveLength(0);
   });
 });

--- a/lib/rules/use-tokens/index.js
+++ b/lib/rules/use-tokens/index.js
@@ -56,7 +56,7 @@ const rule = primaryOption => {
       ruleName,
       {
         actual: primaryOption,
-        possible: true,
+        possible: [true, false],
       },
     );
 


### PR DESCRIPTION
`use-colors`
`use-tokens`
- Fixed an issue where the rule couldn't be disabled and was not validating the rule as expected.