### PR TITLE
NO-JIRA: Allow disables using `false` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.1.3 - Fix secondary issue with disabling rules
+
+**Fixed:**
+`use-colors`
+`use-tokens` - Previous version fixed rule validation, this version fixes allowing rules to be correctly disabled using `false` option.
+
 ## 1.1.2 - Fix issue with disabling rules
 
 **Fixed:**

--- a/lib/rules/use-colors/__tests__/index.test.js
+++ b/lib/rules/use-colors/__tests__/index.test.js
@@ -100,7 +100,7 @@ it('should not run/report issues when disabled', async () => {
     errored,
     results: [{ warnings, invalidOptionWarnings }],
   } = await lint({
-    code: 'a { color: $bpk-color-sky-blue; font-size: 14rem }',
+    code: 'a { color: blue; font-size: 14rem }',
     config: {
       plugins: ['./index.js'],
       rules: {
@@ -112,4 +112,23 @@ it('should not run/report issues when disabled', async () => {
   expect(errored).toBeFalsy();
   expect(warnings).toHaveLength(0);
   expect(invalidOptionWarnings).toHaveLength(0);
+});
+
+it('should error on non-supported options', async () => {
+  const {
+    errored,
+    results: [{ warnings, invalidOptionWarnings }],
+  } = await lint({
+    code: 'a { color: blue; font-size: 14rem }',
+    config: {
+      plugins: ['./index.js'],
+      rules: {
+        'backpack/use-colors': 'warn',
+      },
+    },
+  });
+
+  expect(errored).toBeTruthy();
+  expect(warnings).toHaveLength(0);
+  expect(invalidOptionWarnings).toHaveLength(1);
 });

--- a/lib/rules/use-colors/index.js
+++ b/lib/rules/use-colors/index.js
@@ -62,6 +62,10 @@ const rule = primaryOption => {
       return;
     }
 
+    if (!primaryOption) {
+      return;
+    }
+
     postcssRoot.walkDecls(decl => {
       const { prop, value } = decl;
 

--- a/lib/rules/use-tokens/__tests__/index.test.js
+++ b/lib/rules/use-tokens/__tests__/index.test.js
@@ -135,7 +135,7 @@ describe('Spacing token tests', () => {
       errored,
       results: [{ warnings, invalidOptionWarnings }],
     } = await lint({
-      code: 'a { width: $bpk-spacing-sm; }',
+      code: 'a { width: 10rem; }',
       config: {
         plugins: ['./index.js'],
         rules: {
@@ -147,6 +147,25 @@ describe('Spacing token tests', () => {
     expect(errored).toBeFalsy();
     expect(warnings).toHaveLength(0);
     expect(invalidOptionWarnings).toHaveLength(0);
+  });
+
+  it('should error on non-supported options', async () => {
+    const {
+      errored,
+      results: [{ warnings, invalidOptionWarnings }],
+    } = await lint({
+      code: 'a { width: $bpk-spacing-sm; }',
+      config: {
+        plugins: ['./index.js'],
+        rules: {
+          'backpack/use-tokens': 'warn',
+        },
+      },
+    });
+
+    expect(errored).toBeTruthy();
+    expect(warnings).toHaveLength(0);
+    expect(invalidOptionWarnings).toHaveLength(1);
   });
 });
 

--- a/lib/rules/use-tokens/index.js
+++ b/lib/rules/use-tokens/index.js
@@ -63,6 +63,10 @@ const rule = primaryOption => {
     if (!validOptions) {
       return;
     }
+
+    if (!primaryOption) {
+      return;
+    }
     postcssRoot.walkDecls(decl => {
       const { prop, value } = decl;
 


### PR DESCRIPTION
In https://github.com/Skyscanner/stylelint-plugin-backpack/pull/6 we fixed the rule validation and had thought we fixed allowing disables to work.

We missed that the tests were testing against valid code, and so missed that the `false` option was not turning the rule off as intended.

This PR updates the tests, and adds the expected behaviour.