### PR TITLE
Add no-legacy-rtl rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@
  limitations under the License.
  */
 
+import noLegacyRtlPlugin from './lib/rules/no-legacy-rtl/index.js';
 import useTypographyStylesPlugin from './lib/rules/use-typography-styles/index.js';
 // These are known to cause false positives. They also need updates to work with Stylelint 15+.
 // KOA-6223 to fix or delete completely
@@ -20,6 +21,7 @@ import useTypographyStylesPlugin from './lib/rules/use-typography-styles/index.j
 // import useTokensPlugin from './lib/rules/use-tokens';
 
 export default [
+  noLegacyRtlPlugin,
   // useColorsPlugin,
   // useTokensPlugin,
   useTypographyStylesPlugin,

--- a/lib/rules/no-legacy-rtl/index.js
+++ b/lib/rules/no-legacy-rtl/index.js
@@ -1,0 +1,59 @@
+import stylelint from 'stylelint';
+
+const ruleName = 'backpack/no-legacy-rtl';
+
+const messages = {
+  bpkRtlMixin:
+    'Do not use the `bpk-rtl` mixin. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`).',
+  rtlSelector:
+    'Do not use `html[dir=rtl]` selectors. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`).',
+};
+
+const rule = (primaryOption) => (postcssRoot, postcssResult) => {
+  const validOptions = stylelint.utils.validateOptions(
+    postcssResult,
+    ruleName,
+    {
+      actual: primaryOption,
+      possible: [true, false],
+    },
+  );
+
+  if (!validOptions || !primaryOption) {
+    return;
+  }
+
+  postcssRoot.walkAtRules('include', (atRule) => {
+    // Match bpk-rtl and bpk-rtl() in both direct and namespaced forms (e.g. utils.bpk-rtl)
+    // but not bpk-rtl-foo or other suffixed variants
+    if (/(?:^|\.)bpk-rtl(\s*\(|$)/.test(atRule.params)) {
+      stylelint.utils.report({
+        ruleName,
+        result: postcssResult,
+        message: messages.bpkRtlMixin,
+        node: atRule,
+        word: atRule.params,
+      });
+    }
+  });
+
+  postcssRoot.walkRules((ruleNode) => {
+    // Matches html[dir=rtl] in all valid forms: optional quotes, spaces around =,
+    // and the case-insensitive flag (e.g. html[dir='rtl' i])
+    if (
+      /html\s*\[\s*dir\s*=\s*['"]?rtl['"]?\s*(?:i\s*)?\]/i.test(
+        ruleNode.selector,
+      )
+    ) {
+      stylelint.utils.report({
+        ruleName,
+        result: postcssResult,
+        message: messages.rtlSelector,
+        node: ruleNode,
+        word: ruleNode.selector,
+      });
+    }
+  });
+};
+
+export default stylelint.createPlugin(ruleName, rule);

--- a/lib/rules/no-legacy-rtl/index.test.js
+++ b/lib/rules/no-legacy-rtl/index.test.js
@@ -1,0 +1,133 @@
+import stylelint from 'stylelint';
+
+const config = {
+  plugins: ['./index.js'],
+  rules: {
+    'backpack/no-legacy-rtl': [true],
+  },
+};
+
+it('passes when using CSS logical properties', async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: 'a { margin-inline-start: 8px; }',
+    config,
+  });
+
+  expect(warnings).toHaveLength(0);
+});
+
+it('passes when using unrelated mixins', async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: '@import "~bpk-mixins/index"; a { @include bpk-caption; }',
+    config,
+  });
+
+  expect(warnings).toHaveLength(0);
+});
+
+it('gives an error when using the bpk-rtl mixin', async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: 'a { @include bpk-rtl() { margin-left: 8px; } }',
+    config,
+  });
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].text).toBe(
+    'Do not use the `bpk-rtl` mixin. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`). (backpack/no-legacy-rtl)',
+  );
+});
+
+it('gives an error when using the namespaced utils.bpk-rtl mixin', async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: 'a { @include utils.bpk-rtl { margin-left: 8px; } }',
+    config,
+  });
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].text).toBe(
+    'Do not use the `bpk-rtl` mixin. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`). (backpack/no-legacy-rtl)',
+  );
+});
+
+it("gives an error when using html[dir='rtl'] selector with single quotes", async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: "html[dir='rtl'] a { margin-left: 0; }",
+    config,
+  });
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].text).toBe(
+    'Do not use `html[dir=rtl]` selectors. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`). (backpack/no-legacy-rtl)',
+  );
+});
+
+it('gives an error when using html[dir="rtl"] selector with double quotes', async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: 'html[dir="rtl"] a { margin-left: 0; }',
+    config,
+  });
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].text).toBe(
+    'Do not use `html[dir=rtl]` selectors. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`). (backpack/no-legacy-rtl)',
+  );
+});
+
+it('gives an error when using html[dir=rtl] selector with spaces around =', async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: 'html[dir = rtl] a { margin-left: 0; }',
+    config,
+  });
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].text).toBe(
+    'Do not use `html[dir=rtl]` selectors. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`). (backpack/no-legacy-rtl)',
+  );
+});
+
+it("gives an error when using html[dir='rtl' i] case-insensitive selector", async () => {
+  const {
+    results: [{ warnings }],
+  } = await stylelint.lint({
+    code: "html[dir='rtl' i] a { margin-left: 0; }",
+    config,
+  });
+
+  expect(warnings).toHaveLength(1);
+  expect(warnings[0].text).toBe(
+    'Do not use `html[dir=rtl]` selectors. Use CSS Logical Properties instead (e.g. `margin-inline-start` instead of `margin-left`). (backpack/no-legacy-rtl)',
+  );
+});
+
+it('should error on non-supported options', async () => {
+  const {
+    errored,
+    results: [{ invalidOptionWarnings, warnings }],
+  } = await stylelint.lint({
+    code: 'a { color: blue; }',
+    config: {
+      plugins: ['./index.js'],
+      rules: {
+        'backpack/no-legacy-rtl': 'warn',
+      },
+    },
+  });
+
+  expect(errored).toBeTruthy();
+  expect(warnings).toHaveLength(0);
+  expect(invalidOptionWarnings).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

Adds a new `backpack/no-legacy-rtl` stylelint rule that flags legacy RTL patterns which should be replaced with [CSS Logical Properties](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Logical_Properties).

Flags:
- `@include bpk-rtl()` — direct usage
- `@include utils.bpk-rtl` — namespaced usage
- `html[dir=rtl]` selectors — in all valid forms (quoted, unquoted, spaces around `=`, case-insensitive flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)